### PR TITLE
cmake: update the minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 
 project(cdt)
 


### PR DESCRIPTION
For CMake 4.0, compatibility with versions of CMake older than 3.5 has been removed [1]. Thus, on macOS it leads to the error on build, since Homebrew updates it to version 4.0.

This patch sets the minimum required version to 3.5 for now.

[1]: https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features